### PR TITLE
Updated user model and schema to add favoriteBeach property to user settings.

### DIFF
--- a/api/homeBeach.js
+++ b/api/homeBeach.js
@@ -2,15 +2,17 @@ const MongoClient = require('mongodb').MongoClient;
  
 const assert = require('assert'); 
 
+
+
 //User object to be recieved. (Test object)
 // const user = {
-//     cognitoUserId: "987654231",
-//     fullName: "TestUser2",
-//     email: "test2@email.com",
+//     cognitoUserId: "9876542312",
+//     fullName: "TestUser22",
+//     email: "test22@email.com",
 //     homeBeach: 0,
 //     homeBeachName: "",
 //     longitude:  -117.596620,
-//     latitude: 35.621682
+//     latitude: 12.621682
 // }
 
 //Requires one argument. A user object with at least a 'latitude' and 'longitude'
@@ -26,9 +28,21 @@ const setHomeBeach = async (usr) => {
         latUpper: newUser.latitude + 0.1, 
     };     
 
-    const client = new MongoClient('mongodb+srv://ant:ant123@cluster0-bse6j.mongodb.net/howsthewater?retryWrites=true&w=majority', { useNewUrlParser: true, useUnifiedTopology: true});
+    const client = new MongoClient(process.env.MONGO_API, { useNewUrlParser: true, useUnifiedTopology: true});
     
     const modifyUser = new Promise((resolve, reject) => {
+
+        if(newUser.latitude > 41.99){
+            newUser.homeBeach = 1
+            newUser.homeBeachName = "Pelican State Beach"            
+            return resolve(newUser)
+            
+        }
+        else if(newUser.latitude < 32){
+            newUser.homeBeach = 1636;
+            newUser.homeBeachName = "Border Field State Park";
+            return resolve(newUser)
+        }
         
         client.connect(async function(err, client){
         //error handling during connection
@@ -68,10 +82,6 @@ const setHomeBeach = async (usr) => {
                 newUser.homeBeach = homeBeach[0].ID;
                 newUser.homeBeachName = homeBeach[0].NameMobileWeb;
                 
-                
-                
-                 
-                
                 //Update to user entry in DB - Not currently needed in this iteration
                 // let nUser = await db.collection('users').updateOne({cognitoUserId:{$eq: user.cognitoUserId}},
                 //     {$set: {
@@ -101,6 +111,8 @@ const setHomeBeach = async (usr) => {
             
     
 }   
+
+//setHomeBeach(user)
 
 
 module.exports = setHomeBeach; 

--- a/models/user.js
+++ b/models/user.js
@@ -49,6 +49,10 @@ const UserSchema = new Schema({
   persona: {
     type: String,
     required: false
+  },
+  favoriteBeach: {
+    type: String,
+    required: false
   }
 });
 

--- a/npm-debug.log
+++ b/npm-debug.log
@@ -1,0 +1,45 @@
+0 info it worked if it ends with ok
+1 verbose cli [ '/usr/bin/node', '/usr/bin/npm', 'start' ]
+2 info using npm@3.5.2
+3 info using node@v8.10.0
+4 verbose run-script [ 'prestart', 'start', 'poststart' ]
+5 info lifecycle location_query@1.0.0~prestart: location_query@1.0.0
+6 silly lifecycle location_query@1.0.0~prestart: no script for prestart, continuing
+7 info lifecycle location_query@1.0.0~start: location_query@1.0.0
+8 verbose lifecycle location_query@1.0.0~start: unsafe-perm in lifecycle true
+9 verbose lifecycle location_query@1.0.0~start: PATH: /usr/share/npm/bin/node-gyp-bin:/home/focus/Documents/Lambda/Labs/HowsTheWater/backend/node_modules/.bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin
+10 verbose lifecycle location_query@1.0.0~start: CWD: /home/focus/Documents/Lambda/Labs/HowsTheWater/backend
+11 silly lifecycle location_query@1.0.0~start: Args: [ '-c', 'node app.js' ]
+12 silly lifecycle location_query@1.0.0~start: Returned: code: 1  signal: null
+13 info lifecycle location_query@1.0.0~start: Failed to exec start script
+14 verbose stack Error: location_query@1.0.0 start: `node app.js`
+14 verbose stack Exit status 1
+14 verbose stack     at EventEmitter.<anonymous> (/usr/share/npm/lib/utils/lifecycle.js:232:16)
+14 verbose stack     at emitTwo (events.js:126:13)
+14 verbose stack     at EventEmitter.emit (events.js:214:7)
+14 verbose stack     at ChildProcess.<anonymous> (/usr/share/npm/lib/utils/spawn.js:24:14)
+14 verbose stack     at emitTwo (events.js:126:13)
+14 verbose stack     at ChildProcess.emit (events.js:214:7)
+14 verbose stack     at maybeClose (internal/child_process.js:925:16)
+14 verbose stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:209:5)
+15 verbose pkgid location_query@1.0.0
+16 verbose cwd /home/focus/Documents/Lambda/Labs/HowsTheWater/backend
+17 error Linux 4.15.0-65-generic
+18 error argv "/usr/bin/node" "/usr/bin/npm" "start"
+19 error node v8.10.0
+20 error npm  v3.5.2
+21 error code ELIFECYCLE
+22 error location_query@1.0.0 start: `node app.js`
+22 error Exit status 1
+23 error Failed at the location_query@1.0.0 start script 'node app.js'.
+23 error Make sure you have the latest version of node.js and npm installed.
+23 error If you do, this is most likely a problem with the location_query package,
+23 error not with npm itself.
+23 error Tell the author that this fails on your system:
+23 error     node app.js
+23 error You can get information on how to open an issue for this project with:
+23 error     npm bugs location_query
+23 error Or if that isn't available, you can get their info via:
+23 error     npm owner ls location_query
+23 error There is likely additional logging output above.
+24 verbose exit [ 1, true ]

--- a/schema/schema.js
+++ b/schema/schema.js
@@ -177,7 +177,8 @@ const UserType = new GraphQLObjectType({
     phoneInput: { type: GraphQLString },
     regionInput: { type: GraphQLString },
     beachInput: { type: GraphQLString },
-    persona: { type: GraphQLString }
+    persona: { type: GraphQLString },
+    favoriteBeach: { type: GraphQLString }
   })
 });
 
@@ -249,7 +250,8 @@ const Mutation = new GraphQLObjectType({
         phoneInput: { type: GraphQLString },
         regionInput: { type: GraphQLString },
         beachInput: { type: GraphQLString },
-        persona: { type: GraphQLString }
+        persona: { type: GraphQLString },
+        favoriteBeach: { type: GraphQLString }
       },
       async resolve(parent, args) {
         let user = new User({
@@ -263,7 +265,8 @@ const Mutation = new GraphQLObjectType({
           phoneInput: args.phoneInput,
           regionInput: args.regionInput,
           beachInput: args.beachInput,
-          persona: args.persona
+          persona: args.persona,
+          favoriteBeach: args.favoriteBeach
         });
 
         let mUser = await hb(user);
@@ -282,18 +285,16 @@ const Mutation = new GraphQLObjectType({
         longitude: { type: GraphQLFloat },
         latitude: { type: GraphQLFloat },
         phoneInput: { type: GraphQLString },
-        regionInput: { type: (GraphQLString) },
-        beachInput: { type: (GraphQLString) },
-        persona: { type: (GraphQLString) }
+        regionInput: { type: GraphQLString },
+        beachInput: { type: GraphQLString },
+        persona: { type: GraphQLString },
+        favoriteBeach: { type: GraphQLString }
       },
       resolve(root, args) {
         return new Promise((resolve, reject) => {
           User.findOneAndUpdate(
             {
               cognitoUserId: args.cognitoUserId
-              // regionInput: args.regionInput,
-              // beachInput: args.beachInput,
-              // persona: args.persona
             },
             args,
             {


### PR DESCRIPTION
The functionality for a favorite beach to be set by a user on the front-end has been added. I used this query to test the property by passing in the required cognitoUserId property and a string for the favorite beach.  

You can use whichever user is in the database to test it, you just need to include the cognitoUserId in the query.

```
mutation{
  update(cognitoUserId: "53", favoriteBeach:"Pebble Beach Access"){
    fullName
    email
    homeBeach
    homeBeachName
    longitude
    latitude
    phoneInput
    favoriteBeach
  }
}

```

This will be have to be tested locally on localhost:4444/graphql after starting the server (npm start) under the above-listed branch.